### PR TITLE
Fix #4 [go-webassembly]「Run」ボタンが有効にならない。

### DIFF
--- a/go-webassembly/1_hellowasm/index.html
+++ b/go-webassembly/1_hellowasm/index.html
@@ -26,6 +26,10 @@
             inst = result.instance;
             // 実行ボタンを有効にする
             document.getElementById("runButton").disabled = false;
+        ).catch((err) => {
+          // コンソールにerrorが出力される場合はcloud shellなどで試してください
+          console.error('catch');
+          console.error(err);
         });
 
         // 実行ボタンを押されたときの処理

--- a/go-webassembly/1_hellowasm/index.html
+++ b/go-webassembly/1_hellowasm/index.html
@@ -27,7 +27,7 @@
             // 実行ボタンを有効にする
             document.getElementById("runButton").disabled = false;
         ).catch((err) => {
-          // コンソールにerrorが出力される場合はcloud shellなどで試してください
+          // コンソールにerrorが出力される場合はブラウザの動作環境を確認してください
           console.error('catch');
           console.error(err);
         });

--- a/go-webassembly/2_dom/index.html
+++ b/go-webassembly/2_dom/index.html
@@ -27,7 +27,7 @@
             // 実行ボタンを有効にする
             document.getElementById("runButton").disabled = false;
         }).catch((err) => {
-          // コンソールにerrorが出力される場合はcloud shellなどで試してください
+          // コンソールにerrorが出力される場合はブラウザの動作環境を確認してください
           console.error('catch');
           console.error(err);
         });

--- a/go-webassembly/2_dom/index.html
+++ b/go-webassembly/2_dom/index.html
@@ -26,6 +26,10 @@
             inst = result.instance;
             // 実行ボタンを有効にする
             document.getElementById("runButton").disabled = false;
+        }).catch((err) => {
+          // コンソールにerrorが出力される場合はcloud shellなどで試してください
+          console.error('catch');
+          console.error(err);
         });
 
         // 実行ボタンを押されたときの処理

--- a/go-webassembly/3_clickevent/index.html
+++ b/go-webassembly/3_clickevent/index.html
@@ -27,7 +27,7 @@
             // 実行ボタンを有効にする
             document.getElementById("runButton").disabled = false;
         }).catch((err) => {
-          // コンソールにerrorが出力される場合はcloud shellなどで試してください
+          // コンソールにerrorが出力される場合はブラウザの動作環境を確認してください
           console.error('catch');
           console.error(err);
         });

--- a/go-webassembly/3_clickevent/index.html
+++ b/go-webassembly/3_clickevent/index.html
@@ -26,6 +26,10 @@
             inst = result.instance;
             // 実行ボタンを有効にする
             document.getElementById("runButton").disabled = false;
+        }).catch((err) => {
+          // コンソールにerrorが出力される場合はcloud shellなどで試してください
+          console.error('catch');
+          console.error(err);
         });
 
         // 実行ボタンを押されたときの処理


### PR DESCRIPTION
- wasmロード時にエラーが出たときにはエラーを出力するようにした。
- エラーの解決にこだわらず、cloud shellでやってもらうように促すコメントも追加した。

# 動作確認
再現環境でエラーが出力されるのを確認
<img width="610" alt="2018-09-02 12 00 46" src="https://user-images.githubusercontent.com/1883265/44951819-a4a84f80-aea9-11e8-9a1e-57e760a339a7.png">


# その他
本筋と関係ないので、codelabsに載っているコードの修正はいいかなと思っています。

# 詳細
詳細はissueを参考のこと
https://github.com/golangtokyo/codelab/issues/4

