### PR TITLE
Fix typo - package

### DIFF
--- a/docs/find-gophers/index.html
+++ b/docs/find-gophers/index.html
@@ -500,7 +500,7 @@ func GOPHER() (gopher *Gopher) { // ここ
     
       <google-codelab-step label="おわりに" duration="1">
         <p>このコードラボでは、ソースコードを静的解析することで、識別子の位置や型情報などを取得する方法を解説しました。このコードラボで扱った内容だけでも多くのことをソースコードから得られることができ、自作の開発ツールに活かせることでしょう。</p>
-<p>このコードラボでは単一のソースコードしか扱いませんでしたが、<code>go/build</code>パッケージ（Go1.11からは<code>golang.org/x/tools/go/pacakge</code>パッケージ）などを使うとパッケージで使われているソースコードすべてに対して構文解析や型チェックを行ったりもします。ぜひ、標準パッケージである<a href="https://golang.org/pkg/go" target="_blank"><code>go</code>パッケージ</a>や順標準パッケージである<a href="https://golang.org/x/tools/go" target="_blank"><code>golang.org/x/tools/goパッケージ</code></a>の機能を覗いてみてください。今まで<code>grep</code>や<code>sed</code>を使ってソースコードをテキストファイルとして扱ってきた作業が、静的解析でGoのソースコードとして扱うことで、もっと賢く、精度も高く行えることに気づくでしょう。</p>
+<p>このコードラボでは単一のソースコードしか扱いませんでしたが、<code>go/build</code>パッケージ（Go1.11からは<code>golang.org/x/tools/go/package</code>パッケージ）などを使うとパッケージで使われているソースコードすべてに対して構文解析や型チェックを行ったりもします。ぜひ、標準パッケージである<a href="https://golang.org/pkg/go" target="_blank"><code>go</code>パッケージ</a>や順標準パッケージである<a href="https://golang.org/x/tools/go" target="_blank"><code>golang.org/x/tools/goパッケージ</code></a>の機能を覗いてみてください。今まで<code>grep</code>や<code>sed</code>を使ってソースコードをテキストファイルとして扱ってきた作業が、静的解析でGoのソースコードとして扱うことで、もっと賢く、精度も高く行えることに気づくでしょう。</p>
 
 
       </google-codelab-step>

--- a/docs/go-greeting/index.html
+++ b/docs/go-greeting/index.html
@@ -142,7 +142,7 @@ func Do() {
 <p>Go1.11から試験的に<a href="https://golang.org/cmd/go/#hdr-Modules_and_vendoring" target="_blank">モジュール</a>という機能が導入されました。モジュールを使う場合、<code>go.mod</code>というファイルに書かれた依存関係を基にビルドするため、<code>GOPATH</code>以下に依存ライブラリを置く必要がなくなりました。</p>
 </aside>
 <p><code>GOPATH</code>は複数設定でき、マシン全体の<code>GOPATH</code>を1つ設定するほか、プロジェクトごとに<code>GOPATH</code>を追加で設定する場合もあります。ここでは、<code>3_package/gopath</code>に<code>GOPATH</code>を設定してみましょう。</p>
-<p><code>3_pacakge/gopath</code>以下のディレクトリ構造を<code>tree</code>コマンドで確認してみます。なお、<code>tree</code>コマンドはデフォルトではインストールされてない可能性があります。</p>
+<p><code>3_package/gopath</code>以下のディレクトリ構造を<code>tree</code>コマンドで確認してみます。なお、<code>tree</code>コマンドはデフォルトではインストールされてない可能性があります。</p>
 <pre>$ tree gopath
 gopath
 └── src


### PR DESCRIPTION
ここで typo を見つけたので修正しました。
https://golangtokyo.github.io/codelab/find-gophers/?index=codelab#8

